### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,7 +26,8 @@ jobs:
         java-version: '21'
     - uses: teatimeguest/setup-texlive-action@v3
       with:
-        packages: scheme-basic |
+        packages:  |
+          scheme-basic
           csquotes
     - name: Test literature
       run: |

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,21 +19,22 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v3
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ matrix.python-version }} 
     - name: Setup Java
       uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '21'
     - name: Setup TeX Live
-    - uses: teatimeguest/setup-texlive-action@v3
+      uses: teatimeguest/setup-texlive-action@v3
       with:
         packages: |
           scheme-basic
           csquotes
+          natbib
+          biblatex
     - name: Test literature
-      run: |
-        ./run test
+      run: ./run test
     - name: Archive logs
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -24,13 +24,13 @@ jobs:
       with:
         distribution: 'temurin'
         java-version: '21'
-    - name: Test literature
-      uses: teatimeguest/setup-texlive-action@v3
+    - uses: teatimeguest/setup-texlive-action@v3
       with:
         packages: scheme-basic |
           csquotes
-        run: |
-          ./run test
+    - name: Test literature
+      run: |
+        ./run test
     - name: Archive logs
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -33,6 +33,7 @@ jobs:
           csquotes
           natbib
           biblatex
+          biber
     - name: Test literature
       run: ./run test
     - name: Archive logs

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,21 +12,23 @@ jobs:
       matrix:
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v4
+    - name: Checking out repository
+      uses: actions/checkout@v4
     - name: Check sorting of literature
-      run: |
-        ./run sorted
-    - name: Set up Python ${{ matrix.python-version }}
+      run: ./run sorted
+    - name: Setup Python
       uses: actions/setup-python@v3
       with:
         python-version: ${{ matrix.python-version }}
-    - uses: actions/setup-java@v4
+    - name: Setup Java
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: '21'
+    - name: Setup TeX Live
     - uses: teatimeguest/setup-texlive-action@v3
       with:
-        packages:  |
+        packages: |
           scheme-basic
           csquotes
     - name: Test literature

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,11 +25,11 @@ jobs:
         distribution: 'temurin'
         java-version: '21'
     - name: Test literature
-      uses: xu-cheng/texlive-action@v2
+      uses: teatimeguest/setup-texlive-action@v3
       with:
-        scheme: small
+        packages: scheme-basic |
+          csquotes
         run: |
-          tlmgr install csquotes
           ./run test
     - name: Archive logs
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Changed to an different GitHub action for setting up LaTeX, which seems to be more robust to the 2025 TeX Live update than the current solution.

It also seems to be half a minute faster :)

Also improved the naming of steps.