### PR TITLE
Updated UVLhub entry; added pseudo-Boolean arxiv TR

### DIFF
--- a/literature/MYabrv.bib
+++ b/literature/MYabrv.bib
@@ -314,6 +314,7 @@
 @String{CIM = "Comp. Intell. Mag. (CIM)"}
 @String{CLSS = "Comput.\ Lang.\ Syst.\ Struct."}
 @String{COLA = "J.\ Computer Languages (COLA)"}
+@String{DKE = "Data and Knowledge Engineering (DKE)"}
 @String{ComNet = "Computer Networks"}
 @String{Computer = "IEEE Computer"}
 @String{Constraints = "Constraints"}
@@ -408,6 +409,7 @@
 @String{TOMS = "ACM Trans.\ on Mathematical Software (TOMS)"}
 @String{TOPLAS = "ACM Trans.\ on Programming Languages and Systems (TOPLAS)"}
 @String{TOSEM = "Trans.\ on Software Engineering and Methodology (TOSEM)"}
+@String{TPLP = "Theory and Practice of Logic Programming (TPLP)"}
 @String{TSE = "IEEE Trans.\ on Software Engineering (TSE)"}
 @String{UPGRADE = "The European Journal for the Informatics Professional"}
 @String{WIREs = "WIREs Data Mining and Knowledge Discovery (WIREs)"}

--- a/literature/MYshort.bib
+++ b/literature/MYshort.bib
@@ -318,6 +318,7 @@
 @String{Constraints = "Constraints"}
 @String{CPAIOR = "CPAIOR"}
 @String{CSUR = "CSUR"}
+@String{DKE = "DKE"}
 @String{EJIS = "EJIS"}
 @String{ENTCS = "ENTCS"}
 @String{EMSE = "EMSE"}
@@ -409,6 +410,7 @@
 @String{TOMS = "TOMS"}
 @String{TOPLAS = "TOPLAS"}
 @String{TOSEM = "TOSEM"}
+@String{TPLP = "TPLP"}
 @String{TSE = "TSE"}
 @String{UPGRADE = "UPGRADE"}
 @String{WIREs = "WIREs"}

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -503,9 +503,9 @@
 	title     = {{UVLHub: A Feature Model Data Repository Using UVL and Open Science Principles}},
 	journal   = jss,
 	volume    = {215},
+	doi       = {10.1016/j.jss.2024.112150},
 	publisher = elsevier,
 	year      = 2024,
-	doi = {10.1016/j.jss.2024.112150}
 	ektags    = {reproducibility},
 }
 

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -266,6 +266,16 @@
 	typo3tags = {SupervisorTT, SupervisorPB, VariantSyncMT},
 }
 
+@mastersthesis{Vill25,
+	author    = {Vill, Stefan},
+	title     = {{Pseudo Boolean d-DNNF Compilation for Analyzing Expressive Feature-Model Formats}},
+	type      = master,
+	school    = uniulm,
+	note      = toappear,
+	year      = 2025,
+	typo3tags = {SupervisorCS, SupervisorTT, FMCounting},
+}
+
 @misc{SBK+:ICST25,
 	author    = {Schmidt, Tim Jannik and B{\"{o}}hm, Sabrina and Krieter, Sebastian and Th{\"u}m, Thomas and Acher, Mathieu},
 	title     = {{Poster: Quantification of Feature-Interaction Masking in JHipster}},

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -275,16 +275,6 @@
 	year      = 2025,
 }
 
-@article{RGS+:JSS24,
-	author    = {Romero-Organv{\'\i}dez, David and Galindo, Jos{\'e} A and Sundermann, Chico and Horcas, Jos{\'e}-Miguel and Benavides, David},
-	title     = {{UVLHub: A Feature Model Data Repository Using UVL and Open Science Principles}},
-	journal   = jss,
-	note      = toappear,
-	publisher = elsevier,
-	year      = 2024,
-	ektags    = {reproducibility},
-}
-
 @inproceedings{HOB+:MODEVAR24,
 	comments  = {Will update once CRC available},
 	author    = {He{\ss}, Tobias and Ostheimer, Lukas and Betz, Tobias and Karrer, Simon and Schmidt, Tim Jannik and Coquet, Pierre and Semmler, Sean and Th{\"u}m, Thomas},
@@ -372,6 +362,16 @@
 	month     = feb,
 	year      = 2025,
 	tttags    = {Editorial},
+}
+
+@techreport{SVK+:TR25,
+	author    = {Chico Sundermann and Stefan Vill and Elias Kuiter and Sebastian Krieter and Thomas Thüm and Matthias Tichy},
+	title     = {{Pseudo-Boolean d-DNNF Compilation for Expressive Feature Modeling Constructs}},
+	number    = {arXiv:2505.05976},
+	institution = arxiv,
+	doi       = {10.48550/arXiv.2505.05976},
+	month     = may,
+	year      = 2025,
 }
 
 @techreport{KMP+:TR25subsumedbyKMP+:TOSEM25,
@@ -496,6 +496,17 @@
 	doi       = {10.1016/J.JSS.2024.112087},
 	publisher = elsevier,
 	year      = 2024,
+}
+
+@article{RGS+:JSS24,
+	author    = {Romero-Organv{\'\i}dez, David and Galindo, Jos{\'e} A and Sundermann, Chico and Horcas, Jos{\'e}-Miguel and Benavides, David},
+	title     = {{UVLHub: A Feature Model Data Repository Using UVL and Open Science Principles}},
+	journal   = jss,
+	volume    = {215},
+	publisher = elsevier,
+	year      = 2024,
+	doi = {10.1016/j.jss.2024.112150}
+	ektags    = {reproducibility},
 }
 
 @article{KCP+:SciAdv24,

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -365,10 +365,11 @@
 }
 
 @techreport{SVK+:TR25,
-	author    = {Chico Sundermann and Stefan Vill and Elias Kuiter and Sebastian Krieter and Thomas Thüm and Matthias Tichy},
+	author    = {Sundermann, Chico and Vill, Stefan and Kuiter, Elias and Krieter, Sebastian and Th{\"{u}}m and Tichy, Matthias},
 	title     = {{Pseudo-Boolean d-DNNF Compilation for Expressive Feature Modeling Constructs}},
 	number    = {arXiv:2505.05976},
 	institution = arxiv,
+	note      = {Submitted to TSE},
 	doi       = {10.48550/arXiv.2505.05976},
 	month     = may,
 	year      = 2025,


### PR DESCRIPTION
For any reason, the RGS+:JSS24 entry is deleted everytime by the sort.sh script.