### PR TITLE
fix: duplicate variable "monterey"

### DIFF
--- a/literature/MYabrv.bib
+++ b/literature/MYabrv.bib
@@ -195,7 +195,7 @@
 @String{MISS = "Proc.\ of Workshop on Modularity in Systems Software (MISS)"}
 @String{MODEVAR = "Proc.\ Int'l Workshop on Languages for Modelling Variability (MODEVAR)"}
 @String{MODIQUITOUS = "Proc.\ Workshop on Model-based Interactive Ubiquitous Systems (MODIQUITOUS)"}
-@String{Monterey = "Proc.\ Monterey Workshop on Development, Operation and Management of Large-Scale Complex IT Systems"}
+@String{MontereyWorkshop = "Proc.\ Monterey Workshop on Development, Operation and Management of Large-Scale Complex IT Systems"}
 @String{MultiPLE = "Proc.\ Int'l Workshop on Multi Product Line Engineering (MultiPLE)"}
 @String{MUTATION = "Proc.\ Int'l Workshop on Mutation Analysis (MUTATION)"}
 @String{MVOOPL = "Proc.\ Workshop on Modelling Variability for Object-Oriented Product Lines (MVOOPL)"}

--- a/literature/MYshort.bib
+++ b/literature/MYshort.bib
@@ -203,7 +203,7 @@
 @String{MBEES = "MBEES"}
 @String{MODEVAR = "MODEVAR"}
 @String{MODIQUITOUS = "MODIQUITOUS"}
-@String{Monterey = "Monterey Workshop"}
+@String{MontereyWorkshop = "Monterey Workshop"}
 @String{MultiPLE = "MultiPLE"}
 @String{MUTATION = "MUTATION"}
 @String{MVOOPL = "MVOOPL"}

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -17270,7 +17270,7 @@
 @inproceedings{HRRS:Monterey12,
 	author    = {Haber, Arne and Rendel, Holger and Rumpe, Bernhard and Schaefer, Ina},
 	title     = {{Evolving Delta-Oriented Software Product Line Architectures}},
-	booktitle = monterey,
+	booktitle = MontereyWorkshop,
 	pages     = {183--208},
 	doi       = {10.1007/978-3-642-34059-8_10},
 	publisher = springer,


### PR DESCRIPTION
I fixed the duplication by renaming the variable for the workshop accordingly. It was used only once, and I adapted that usage accordingly.