### PR TITLE
Fixes, VariantSync Updates, Update on Sabrina's Papers

### DIFF
--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -193,6 +193,7 @@
 	location  = {Rio de Janeiro, Brazil},
 	note      = toappear,
 	year      = 2026,
+	typo3tags = {VariantSyncPub},
 }
 
 @article{WTBA:CACM25,
@@ -655,6 +656,7 @@
 	ektags    = {category theory},
 	keywords  = {configuration, language semantics, software product lines, variation},
 	numpages  = {33},
+	typo3tags = {VariantSyncPub},
 }
 
 @article{BKK:FSE24,
@@ -854,6 +856,7 @@
 	isbn      = {9798400705939},
 	keywords  = {software evolution, software product lines, software variability},
 	numpages  = {12},
+	typo3tags = {VariantSyncPub},
 }
 
 @inproceedings{HKO:SPLC24,

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -373,13 +373,16 @@
 	typo3tags = {SupervisorCS, SupervisorTT, FMCounting},
 }
 
-@misc{SBK+:ICST25,
+@inproceedings{SBK+:ICST25,
 	author    = {Schmidt, Tim Jannik and B{\"{o}}hm, Sabrina and Krieter, Sebastian and Th{\"u}m, Thomas and Acher, Mathieu},
 	title     = {{Poster: Quantification of Feature-Interaction Masking in JHipster}},
-	note      = toappear # {, Poster at International Conference on Software Testing, Verification and Validation},
-	howpublished = poster,
+	booktitle = icst,
+	publisher = ieee,
+	address   = washington,
+    pages     = {1--4},
 	month     = mar,
 	year      = 2025,
+    doi       = {10.1109/ICST62969.2025.10989017},
 }
 
 @techreport{TRLA:TR25,

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -303,11 +303,12 @@
 	author    = {B{\"{o}}hm, Sabrina and Schmidt, Tim and Krieter, Sebastian and Pett, Tobias and Th{\"u}m, Thomas and Lochau, Malte},
 	title     = {{Coverage Metrics for T-Wise Feature Interactions}},
 	booktitle = icst,
-	note      = toappear,
+    pages     = {198--209},
 	publisher = ieee,
 	address   = washington,
 	month     = mar,
 	year      = 2025,
+	doi       = {10.1109/ICST62969.2025.10989003},
 }
 
 @inproceedings{GSS+:VaMoS25,

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -312,6 +312,7 @@
 	type      = master,
 	school    = uniulm,
 	note      = toappear,
+	address   = germany,
 	year      = 2025,
 	typo3tags = {SupervisorCS, SupervisorTT, FMCounting},
 }

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -967,6 +967,7 @@
 }
 
 @inproceedings{BVO+:EASE24,
+	renamedfrom = {BvDO+:EASE24},
 	author    = {Alexander Boll and Yael Van Dok and Manuel Ohrndorf and Alexander Schulthei{\ss} and Timo Kehrer},
 	title     = {{Towards Semi-Automated Merge Conflict Resolution: Is It Easier Than We Expected?}},
 	booktitle = ease,
@@ -1098,18 +1099,6 @@
 	ektags    = {KConfig},
 	isbn      = {9798400708770},
 	numpages  = {5},
-}
-
-@inproceedings{BvDO+:EASE24,
-	author    = {Alexander Boll and Yael Van Dok and Manuel Ohrndorf and Alexander Schulthei{\ss} and Timo Kehrer},
-	title     = {{Towards Semi-Automated Merge Conflict Resolution: Is It Easier Than We Expected?}},
-	booktitle = ease,
-	pages     = {282--292},
-	location  = {Salerno, Italy},
-	doi       = {10.1145/3661167.3661197},
-	publisher = acm,
-	address   = ny,
-	year      = 2024,
 }
 
 @inproceedings{ZCPA:FormaliSE24,

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -641,7 +641,7 @@
 	title     = {{Unparsing von Datenstrukturen zur Analyse von C-Präprozessor-Variabilität}},
 	type      = bachelor,
 	school    = unipaderborn,
-	doi       = {10.17619/UNIPB/1-2306},
+	doi       = {10.17619/UNIPB/1-2385},
 	address   = germany,
 	month     = jan,
 	year      = 2025,

--- a/literature/literature.bib
+++ b/literature/literature.bib
@@ -314,6 +314,7 @@
 	school    = uniulm,
 	note      = toappear,
 	address   = germany,
+	month     = mar,
 	year      = 2025,
 	typo3tags = {SupervisorCS, SupervisorTT, FMCounting},
 }


### PR DESCRIPTION
- fix: remove duplicate BvDO+:EASE24; original entry: BDO+:EASE24 ([6a032dd](https://github.com/TUBS-ISF/BibTags/pull/51/commits/6a032dd667ab5cfc96c413baa6aee7fe53665d1d))
- fix: add address to Vill25 ([044ad8f](https://github.com/TUBS-ISF/BibTags/pull/51/commits/044ad8fbd1c0f65459e0662f6eceab968bd35ec2))
- update typo3 tags for VariantSync papers ([b2446e1](https://github.com/TUBS-ISF/BibTags/pull/51/commits/b2446e1680004a4409c215945e1b6582fda088de))
- updated two of @sabrinaboehm 's papers which are published by now ([SBK+:ICST25](https://github.com/TUBS-ISF/BibTags/pull/51/commits/6a4bb15aedda2d1e4a776c8f5c37dc65ce4325c0) and [BSK+:ICST25](https://github.com/TUBS-ISF/BibTags/pull/51/commits/d26936eda2dc716447b774d7816b01a74ee03ac2))